### PR TITLE
Removed code incompatible with PHP 5.2.*

### DIFF
--- a/libraries/drivers/log/file.php
+++ b/libraries/drivers/log/file.php
@@ -10,7 +10,7 @@ class FileLog
         if (!$config_dir)
             die('Please provide a log directory in your config file');
         else {
-            $this->_dir = __dir__.'/../../../'.$config_dir.'/'.PHP_SAPI.'/';
+            $this->_dir = dirname(__FILE__).'/../../../'.$config_dir.'/'.PHP_SAPI.'/';
 
             if (!is_writable($this->_dir))
                 if (!mkdir($this->_dir, 0755, True))


### PR DESCRIPTION
Removed code incompatible with PHP 5.2.*. **dir** constant is only available since PHP 5.3.
