### PR TITLE
Display selected server on top in navigation

### DIFF
--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -9,3 +9,7 @@
 textarea {
 	width: 232px;
 }
+.nav-pills>li.server>a {
+    padding-right: 6px;
+    font-size: 90%;
+}

--- a/views/navigation.php
+++ b/views/navigation.php
@@ -1,41 +1,35 @@
 <ul class="nav nav-pills nav-stacked">
-    <li class="nav-header">Servers & databases</li>
-    <?php foreach ($this->app->config['database']['redis'] as $serverId => $server): ?>
+    <li class="nav-header">Server & databases</li>
+    <li class="server active">
+        <a href="<?=$this->router->url?>/welcome/index/<?= $this->app->current['serverId'] . '/0' ?>">
+            <i class="icon-chevron-down"></i> <?= $this->app->current['host'] ?>:<?= $this->app->current['port'] ?>
+        </a>
+    </li>
+    <?php foreach ($this->app->current['dbs'] as $database): ?>
         <?php 
-            if ($serverId == $this->app->current['serverId']) {
-                $serverClass = 'active';
-                $serverIcon = 'icon-chevron-down';
+            if ($database == $this->app->current['database']) {
+                $dbClass = 'active';
+                $dbIcon = 'icon-ok-sign';
             } 
             else {
-                $serverClass = '';
-                $serverIcon = 'icon-chevron-right';
+                $dbClass = '';
+                $dbIcon = '';
             }
         ?>
-        <li class="<?= $serverClass ?>">
-            <a href="<?=$this->router->url?>/welcome/index/<?= $serverId . '/0' ?>">
-                <i class="<?= $serverIcon ?>"></i> 
-                <?= $server['host'] ?>:<?= $server['port'] ?>
+        <li class="database <?= $dbClass ?>">
+            <a href="<?=$this->router->url?>/welcome/index/<?= $this->app->current['serverId'] . '/' . $database ?>">
+                <i class="<?= $dbIcon ?>"></i> DB <?= $database ?>
             </a>
         </li>
-        <?php if ($serverId == $this->app->current['serverId']) : ?>
-            <?php foreach ($this->app->current['dbs'] as $database): ?>
-                <?php 
-                    if ($database == $this->app->current['database']) {
-                        $dbClass = 'active';
-                        $dbIcon = 'icon-ok-sign';
-                    } 
-                    else {
-                        $dbClass = '';
-                        $dbIcon = '';
-                    }
-                ?>
-                <li class="<?= $dbClass ?>">
-                    <a href="<?=$this->router->url?>/welcome/index/<?= $serverId . '/' . $database ?>">
-                        <i class="<?= $dbIcon ?>"></i> 
-                        DB <?= $database ?>
-                    </a>
-                </li>
-            <?php endforeach; ?>
+    <?php endforeach; ?>
+    <li class="nav-header">Other servers</li>    
+    <?php foreach ($this->app->config['database']['redis'] as $serverId => $server): ?>
+        <?php if ($serverId != $this->app->current['serverId']) : ?>
+            <li class="server">
+                <a href="<?=$this->router->url?>/welcome/index/<?= $serverId . '/0' ?>">
+                    <i class="icon-chevron-right"></i> <?= $server['host'] ?>:<?= $server['port'] ?>
+                </a>
+            </li>
         <?php endif; ?>
     <?php endforeach; ?>  
 </ul>                                


### PR DESCRIPTION
If there are many servers in navigation column (more than 10 in my case) - then current server can be displayed in the same bottom of the page. In this case it is not handy to navigate through its databases because every time you should scroll to the page bottom.

This fix displays selected server on the top in navigation.
