### PR TITLE
Fixed regex for DB key count

### DIFF
--- a/config.php
+++ b/config.php
@@ -30,7 +30,8 @@ $config = Array(
                     'database' => 0,
                 ),
             ),
-        )
+        ),
+        'names' => Array(), /* Name databases. key should be database id and value is the name */
     ),
     'session' => Array(
         'lifetime'       => 7200,

--- a/libraries/controller.php
+++ b/libraries/controller.php
@@ -23,7 +23,6 @@ class Controller
         
         $info = $this->db->info();
         $dbs = $this->infoModel->getDbs($info);
-
         if (!in_array($config['dbId'], $dbs)) {
             $config['dbId'] = $dbs[0];
         }
@@ -35,12 +34,12 @@ class Controller
                 $current['dbs'][] = array(
                     'id' => $i,
                     'keys' => $matches[1],
+                    'name' => $this->app->config['database']['names'][$i],
                 );
             }
         }
-        
         $this->db->select($current['database']);
-        
+
         $this->app->current = $current;
     }
 

--- a/views/navigation.php
+++ b/views/navigation.php
@@ -18,7 +18,8 @@
         ?>
         <li class="database <?= $dbClass ?>">
             <a href="<?=$this->router->url?>/welcome/index/<?= $this->app->current['serverId'] . '/' . $database['id'] ?>">
-                <i class="<?= $dbIcon ?>"></i> DB <?= $database['id'] ?> <span class="label pull-right" title="Number of keys"><?= $database['keys'] ?></span>
+                <i class="<?= $dbIcon ?>"></i> <?= ($database['name'] !== null ? $database['name'] : "DB ".$database['id']) ?>
+                <span class="label pull-right" title="Number of keys"><?= $database['keys'] ?></span>
             </a>
         </li>
     <?php endforeach; ?>


### PR DESCRIPTION
Fix for Issue #26.

This fixed a broken regex. My `$info["db<number>"]` variable had the following format: `keys=1,expires=0,avg_ttl=0`. The `$` asserted that `expires` was at the end of the string when, in my case, it was not. Not sure if this is due to different redis configs / versions.
