### PR TITLE
Fixes active navigation

### DIFF
--- a/views/layout.php
+++ b/views/layout.php
@@ -105,45 +105,33 @@
                         <a class="brand" href="<?=$this->router->url?>">PHPRedmin</a>
                         <div class="nav-collapse collapse navbar-responsive-collapse">
                             <ul class="nav">
-                                <li <?php if($this->router->request == $this->router->url) {?>
-                                    class="active"<
-                                <?php } ?>>
+                                <li<?= (strstr($this->router->request, "/welcome/index/") ? ' class="active"' :null)?>>
                                     <a href="<?=$this->router->url?>/welcome/index/<?= $this->app->current['serverId'] . '/' . $this->app->current['database'] ?>">
                                         <i class="icon-white icon-home"></i> Home
                                     </a>
                                 </li>
-                                <li <?php if($this->router->request == $this->router->url."/welcome/info/") {?>
-                                    class="active"<
-                                <?php } ?>>
+                                <li<?= (strstr($this->router->request, "/welcome/info/") ? ' class="active"' :null)?>>
                                     <a href="<?=$this->router->url?>/welcome/info/<?= $this->app->current['serverId'] . '/' . $this->app->current['database'] ?>">
                                         <i class="icon-white icon-info-sign"></i> Info
                                     </a>
                                 </li>
-                                <li <?php if($this->router->request == $this->router->url."/welcome/config") {?>
-                                    class="active"<
-                                <?php } ?>>
+                                <li<?= (strstr($this->router->request, "/welcome/config/") ? ' class="active"' :null)?>>
                                     <a href="<?=$this->router->url?>/welcome/config/<?= $this->app->current['serverId'] . '/' . $this->app->current['database'] ?>">
                                         <i class="icon-white icon-cogs"></i> Configurations
                                     </a>
                                 </li>
-                                <li <?php if($this->router->request == $this->router->url."/welcome/stats") {?>
-                                    class="active"<
-                                <?php } ?>>
+                                <li<?= (strstr($this->router->request, "/welcome/stats/") ? ' class="active"' :null)?>>
                                     <a href="<?=$this->router->url?>/welcome/stats/<?= $this->app->current['serverId'] . '/' . $this->app->current['database'] ?>">
                                         <i class="icon-white icon-bar-chart"></i> Stats
                                     </a>
                                 </li>
-                                <li <?php if($this->router->request == $this->router->url."/welcome/slowlog") {?>
-                                    class="active"<
-                                <?php } ?>>
+                                <li<?= (strstr($this->router->request, "/welcome/slowlog/") ? ' class="active"' :null)?>>
                                     <a href="<?=$this->router->url?>/welcome/slowlog/<?= $this->app->current['serverId'] . '/' . $this->app->current['database'] ?>">
                                         <i class="icon-white icon-warning-sign"></i> Slow Log
                                     </a>
                                 </li>
                                 <?php if (App::instance()->config['terminal']['enable']): ?>
-                                    <li <?php if($this->router->request == $this->router->url."/terminal/") {?>
-                                        class="active"<
-                                    <?php } ?>>
+                                    <li<?= (strstr($this->router->request, "/terminal/") ? ' class="active"' :null)?>>
                                         <a href="<?=$this->router->url?>/terminal/index/<?= $this->app->current['serverId'] . '/' . $this->app->current['database'] ?>">
                                             <i class="icon-white icon-terminal"></i> Terminal
                                         </a>


### PR DESCRIPTION
Setting active class wasn't working, probably a relic from a previous change to request URL. This fixes it by simply looking for a specific string in the request url.

Side note: would it be a better idea to make a navigation array somewhere and simply loop it? That way if we ever need to change it we can do it once.
