### PR TITLE
Forgotten "php" after <? tag

### DIFF
--- a/views/welcome/info.php
+++ b/views/welcome/info.php
@@ -66,7 +66,7 @@
                     <?=$this->info['connected_slaves']?>
                 </td>
             </tr>
-        <? } ?>
+        <?php } ?>
         <tr>
             <td>
                 Used Memory:


### PR DESCRIPTION
With short_open_tags disabled in php configuration "<?" alone is not a valid opening tag and php interpreter gives a syntax error :)
