### PR TITLE
Dont create log dir when threshold config=0

### DIFF
--- a/libraries/drivers/log/file.php
+++ b/libraries/drivers/log/file.php
@@ -2,25 +2,31 @@
 class FileLog
 {
     protected $_dir;
+    protected $threshold;
 
     public function __construct()
     {
         $config_dir = App::instance()->config['log']['file']['directory'];
+        
+        $this->threshold = App::instance()->config['log']['threshold'];
+        
+        if($this->threshold > 0){
 
-        if (!$config_dir)
-            die('Please provide a log directory in your config file');
-        else {
-            $this->_dir = dirname(__FILE__).'/../../../'.$config_dir.'/'.PHP_SAPI.'/';
+            if (!$config_dir)
+                die('Please provide a log directory in your config file');
+            else {
+                $this->_dir = dirname(__FILE__).'/../../../'.$config_dir.'/'.PHP_SAPI.'/';
 
-            if (!is_writable($this->_dir))
-                if (!mkdir($this->_dir, 0755, True))
-                    die("{$this->_dir} does not exist or is not writable");
+                if (!is_writable($this->_dir))
+                    if (!mkdir($this->_dir, 0755, True))
+                        die("{$this->_dir} does not exist or is not writable");
+            }
         }
     }
 
     public function write($type, $msg, $namespace = Null)
     {
-        if (App::instance()->config['log']['threshold'] < Log::instance()->$type)
+        if ($this->threshold < Log::instance()->$type)
             return;
 
         $logfile = $this->_dir.date('Y-m-d').'.log';


### PR DESCRIPTION
When threshold config = 0 the application was still trying to create the log sub directory. Leading to error if we dont create the logs parent directory.

I would also advice to use 0 as the default config for threshold. It will allow slightly easyest demployement because you dont have to create+chmod the log directory.
