### PR TITLE
HTTP_X_FORWARDED_PROTO is not always set

### DIFF
--- a/libraries/router.php
+++ b/libraries/router.php
@@ -29,7 +29,10 @@ final class router
     protected function parse()
     {
         $this->method   = $_SERVER['REQUEST_METHOD'];
-        $this->protocol = ((isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] && $_SERVER['HTTPS'] !== 'off') || $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https') ? 'https' : 'http';
+        $this->protocol = (
+            (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] && $_SERVER['HTTPS'] !== 'off')
+            || (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https')
+        ) ? 'https' : 'http';
         $this->host     = $_SERVER['HTTP_HOST'];
         $this->baseUrl  = $this->protocol.'://'.$this->host;
         $this->url      = $this->protocol.'://'.$this->host.$_SERVER['SCRIPT_NAME'];


### PR DESCRIPTION
We cannot assume HTTP_X_FORWARDED_PROTO is set by default. Also add an
isset check before using it.

Signed-off-by: BlackEagle <ike.devolder@gmail.com>