### PR TITLE
Include custom config WHEN present

### DIFF
--- a/libraries/app.php
+++ b/libraries/app.php
@@ -7,7 +7,7 @@ final class app
 
     protected function __construct()
     {
-        $this->_data['config']  = include_once(file_exists('../config.dist.php') ? '../config.dist.php' : '../config.php');
+        $this->_data['config']  = include_once(file_exists('../config.php') ? '../config.php' : '../config.dist.php');
         $this->_data['drivers'] = 'drivers/';
     }
 


### PR DESCRIPTION
Reverted the logic:
- `config.php` could not exists
- `config.dist.php` should exists by design instead