### PR TITLE
Add Authentication Configuration Instruction in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,8 @@ $config = array(
 );
 ...
 ```
-Remove the ```auth``` section with disable the authentication.
+
+Remove the ```auth``` section in the config file to disable the protection.
 
 _Note:_ You should use the [password_hash](http://php.net/manual/en/function.password-hash.php) function with your desired password and store the result in the ```password``` key, instead of storing the plaintext password as in the code above.
 

--- a/README.md
+++ b/README.md
@@ -25,13 +25,13 @@ Apache configuration example (/etc/httpd/conf.d/phpredmin.conf):
 
 ```ApacheConf
 # phpredmin - Simple web interface to manage and monitor your Redis
-# 
+#
 # Allows only localhost by default
 
 Alias /phpredmin /var/www/phpredmin/public
 
 <Directory /var/www/phpredmin/>
-   AllowOverride All 
+   AllowOverride All
 
    <IfModule mod_authz_core.c>
      # Apache 2.4
@@ -53,6 +53,29 @@ Alias /phpredmin /var/www/phpredmin/public
 
 _Note:_ If your redis server is on an IP or port other than defaults (localhost:6379), you should edit config.php file
 
+## Configuration
+
+### Basic Authentication
+
+By default, the dashboard is password protected using Basic Authentication Mechanism, with the default username and password set to ```admin```.
+
+You can find the ```auth``` config section inside the ```config.dist.php``` file, below is the default configuration:
+
+```
+...
+$config = array(
+...
+'auth' => array(
+  'username' => 'admin',
+  'password' => password_hash('admin', PASSWORD_DEFAULT)
+),
+...
+);
+...
+```
+Remove the ```auth``` section with disable the authentication.
+
+_Note:_ You should use the [password_hash](http://php.net/manual/en/function.password-hash.php) function with your desired password and store the result in the ```password``` key, instead of storing the plaintext password as in the code above.
 ## Features
 
 ### Multi-Server functionality

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ $config = array(
 Remove the ```auth``` section with disable the authentication.
 
 _Note:_ You should use the [password_hash](http://php.net/manual/en/function.password-hash.php) function with your desired password and store the result in the ```password``` key, instead of storing the plaintext password as in the code above.
+
 ## Features
 
 ### Multi-Server functionality

--- a/config.dist.php
+++ b/config.dist.php
@@ -6,7 +6,7 @@ $config = array(
     'default_layout'     => 'layout',
     'timezone'           => 'Europe/Amsterdam',
     'auth' => array(
-	    'username' => 'admin',
+        'username' => 'admin',
         'password' => password_hash('admin', PASSWORD_DEFAULT)
 	),
     'log' => array(

--- a/public/index.php
+++ b/public/index.php
@@ -29,17 +29,20 @@ if (isset(App::instance()->config['auth'])) {
 
     $auth = App::instance()->config['auth'];
 
-    // mod_php
-    if (isset($_SERVER['PHP_AUTH_USER'])) {
-        $username = $_SERVER['PHP_AUTH_USER'];
-        $password = $_SERVER['PHP_AUTH_PW'];
-    // most other servers
-    } elseif (isset($_SERVER['HTTP_AUTHORIZATION']) && strpos(strtolower($_SERVER['HTTP_AUTHORIZATION']), 'basic') === 0) {
-		list($username, $password) = explode(':', base64_decode(substr($_SERVER['HTTP_AUTHORIZATION'], 6)));
-	}
+if(isset($auth['username']) && isset($auth['password']))
+    {
+        // mod_php
+        if (isset($_SERVER['PHP_AUTH_USER'])) {
+            $username = $_SERVER['PHP_AUTH_USER'];
+            $password = $_SERVER['PHP_AUTH_PW'];
+            // most other servers
+        } elseif (isset($_SERVER['HTTP_AUTHORIZATION']) && strpos(strtolower($_SERVER['HTTP_AUTHORIZATION']), 'basic') === 0) {
+      		list($username, $password) = explode(':', base64_decode(substr($_SERVER['HTTP_AUTHORIZATION'], 6)));
+        }
 
-    if ($username != $auth['username'] || !password_verify($password, $auth['password'])) {
-        $authenticated = false;
+        if ($username != $auth['username'] || !password_verify($password, $auth['password'])) {
+            $authenticated = false;
+        }
     }
 }
 


### PR DESCRIPTION
I've add the instruction to configure authentication, and add a condition to skip the authentication in case the configuration is missing or in complete.