### PR TITLE
Undefined index REQUEST_METHOD and HTTP_HOST while running the cron job

### DIFF
--- a/libraries/router.php
+++ b/libraries/router.php
@@ -28,12 +28,19 @@ final class router
 
     protected function parse()
     {
-        $this->method   = $_SERVER['REQUEST_METHOD'];
+
+        if (PHP_SAPI != 'cli') {
+            $this->method = $_SERVER['REQUEST_METHOD'];
+            $this->host = $_SERVER['HTTP_HOST'];
+        } else {
+            $this->method = self::GET;
+            $this->host = null;
+        }
+
         $this->protocol = (
             (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] && $_SERVER['HTTPS'] !== 'off')
             || (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https')
         ) ? 'https' : 'http';
-        $this->host     = $_SERVER['HTTP_HOST'];
         $this->baseUrl  = $this->protocol.'://'.$this->host;
         $this->url      = $this->protocol.'://'.$this->host.$_SERVER['SCRIPT_NAME'];
         $this->path     = '';


### PR DESCRIPTION
Running the cron job throws a PHP notice "undefined index" because the $_SERVER['REQUEST_METHOD'] and the $_SERVER['HTTP_HOST'] variable are not set when running in cli mode.

```
[11-Jan-2017 22:00:01 Europe/Amsterdam] PHP Notice:  Undefined index: HTTP_HOST in /var/www/phpredmin/libraries/router.php on line 37
[11-Jan-2017 22:01:01 Europe/Amsterdam] PHP Notice:  Undefined index: REQUEST_METHOD in /var/www/phpredmin/libraries/router.php on line 31
```

