### PR TITLE
Add option to disable basic authentication when using docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,12 @@ $config = array(
 
 Remove the ```auth``` section in the config file to disable the protection.
 
+If you are using docker, setting a blank username and/or password will also disable the protection.
+
+```
+-e "PHPREDMIN_AUTH_USERNAME="
+```
+
 _Note:_ You should use the [password_hash](http://php.net/manual/en/function.password-hash.php) function with your desired password and store the result in the ```password``` key, instead of storing the plaintext password as in the code above.
 
 ## Features

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '3'
+services:
+    phpredmin:
+        # image: sasanrose/phpredmin
+        build: .
+        environment:
+            - PHPREDMIN_DATABASE_REDIS_0_HOST=redis
+            - PHPREDMIN_AUTH_USERNAME=root
+        ports:
+            - "8089:80"
+        depends_on:
+            - redis
+    redis:
+        image: redis

--- a/public/index.php
+++ b/public/index.php
@@ -29,7 +29,7 @@ if (PHP_SAPI !== 'cli' && isset(App::instance()->config['auth'])) {
 
     $auth = App::instance()->config['auth'];
 
-if(isset($auth['username']) && isset($auth['password']))
+if(isset($auth['username']) && isset($auth['password']) && !empty($auth['username']) && !empty($auth['password']))
     {
         // mod_php
         if (isset($_SERVER['PHP_AUTH_USER'])) {


### PR DESCRIPTION
We should be able to disable basic authentication by setting `PHPREDMIN_AUTH_USERNAME` to and empty string. My last PR only check if the variable is set and thus require authentication even when the username/password is empty. This should disable the authentication if username and/or password is empty.